### PR TITLE
Update method to detect text generation status

### DIFF
--- a/assets/extension.json
+++ b/assets/extension.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.1.1",
+  "version": "1.2.0",
   "gitUrl": "https://github.com/DavG25/text-generation-webui-code_syntax_highlight"
 }

--- a/assets/main.js
+++ b/assets/main.js
@@ -12,15 +12,11 @@
  *
  * performance_mode: if set to true, the extension will wait until text generation
  * ends before highlighting the code on the page to use less resources
- *
  */
 const dataProxy = document.getElementById('code-syntax-highlight');
 let params = JSON.parse(dataProxy.getAttribute('params'));
 
-/*
- * Update the global 'isGeneratingText' value and trigger related actions
- *
- */
+// Update the global 'isGeneratingText' value and trigger related actions
 let isGeneratingText = false;
 function setTextGenerationStatus(newGeneratingStatus) {
   isGeneratingText = newGeneratingStatus;
@@ -311,7 +307,6 @@ function setParams(newParams) {
  * This method is far more reliable then using a proxy and waiting for Gradio
  * to send us the updated values, as sometimes Gradio doesn't correctly queue
  * events and some data is lost
- *
  */
 const paramNames = Object.keys(params);
 paramNames.forEach((paramName) => {

--- a/assets/main.js
+++ b/assets/main.js
@@ -214,21 +214,22 @@ function removeHighlight() {
  * (2) Are there any code blocks in the DOM?
  *  -> If no, stop
  *  -> If yes, continue to (3)
- * (3) Is text still being generated?
+ * (3) We wait a period of milliseconds defined in 'performanceHighlightWaitPeriod'
+ * (4) Is text still being generated?
  *  -> If yes, go back to (3)
- *  -> If no, continue to (4)
- * (4) We highlight all code blocks present on the page
+ *  -> If no, we highlight all code blocks present on the page
  *
  * We need to highlight all code blocks again every time the DOM finishes
  * updating, because the text generation overrides the classes set by highlight.js
  */
-let highlightTimeout;
+let performanceHighlightTimeout;
+const performanceHighlightWaitPeriod = 100;
 function performanceHighlight() {
-  clearTimeout(highlightTimeout);
-  highlightTimeout = setTimeout(() => {
+  clearTimeout(performanceHighlightTimeout);
+  performanceHighlightTimeout = setTimeout(() => {
     if (isGeneratingText === false) highlightCode();
     else performanceHighlight();
-  }, 100);
+  }, performanceHighlightWaitPeriod);
 }
 
 // Watch for changes in the DOM body with arrive.js to highlight new code blocks as they appear

--- a/assets/main.js
+++ b/assets/main.js
@@ -18,18 +18,15 @@ const dataProxy = document.getElementById('code-syntax-highlight');
 let params = JSON.parse(dataProxy.getAttribute('params'));
 
 /*
- * Detect the current text generation status by intercepting
- * the WebSocket messages received by the Web UI
+ * Update the UI elements when the current status of text generation changes
  *
- * We only parse the WebSocket message as JSON when we detect
- * a 'process_starts' or 'process_completed' string inside of it
+ * We lock the extension settings from being modified while text is being generated
  *
- * This could cause the WebSocket message to be parsed if the inner content has either of those
- * strings, but in that case the resulting generation status will still be the right one, as
- * we detect it from the parsed message in the end
+ * Locking the settings avoids a weird bug where some events (such as a checkbox
+ * changing value) are sometimes not registered when text is being generated
  *
- * Using this method will also intercept other loading operations,
- * but that is a minor downside with no impact in this case
+ * This behavior should be investigated to understand why it happens
+ * and if it's something related to the Web UI or Gradio itself
  */
 let isGeneratingText = false;
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -34,9 +34,29 @@ let params = JSON.parse(dataProxy.getAttribute('params'));
 let isGeneratingText = false;
 
 const settingsAccordion = document.getElementById('code-syntax-highlight_accordion');
+// Find the settings title element inside the accordion by its text
+function findElementByText(node, searchText) {
+  let foundElement = null;
+  const traverseNodes = (inputNode) => {
+    if (foundElement) return;
+    if (inputNode.nodeType === Node.TEXT_NODE && inputNode.textContent.trim() === searchText) {
+      foundElement = inputNode.parentNode;
+      return;
+    }
+    if (inputNode.childNodes) {
+      Array.from(inputNode.childNodes).forEach((childNode) => {
+        traverseNodes(childNode);
+      });
+    }
+  };
+  traverseNodes(node);
+  return foundElement;
+}
+const settingsTitle = findElementByText(settingsAccordion, 'Code Syntax Highlight - Settings');
 
 // Disable the settings menu and prevent any setting change
 function disableSettingsAccordion() {
+  if (settingsTitle) settingsTitle.textContent = 'Code Syntax Highlight - Settings (processing)';
   settingsAccordion.classList.add('disabled');
   Array.from(document.querySelectorAll('#code-syntax-highlight_accordion input')).forEach((inputElement) => {
     inputElement.disabled = true;
@@ -47,6 +67,7 @@ function disableSettingsAccordion() {
 }
 // Enable the settings menu and allow settings changes
 function enableSettingsAccordion() {
+  if (settingsTitle) settingsTitle.textContent = 'Code Syntax Highlight - Settings';
   settingsAccordion.classList.remove('disabled');
   Array.from(document.querySelectorAll('#code-syntax-highlight_accordion input')).forEach((inputElement) => {
     inputElement.disabled = false;

--- a/assets/main.js
+++ b/assets/main.js
@@ -312,6 +312,8 @@ const paramNames = Object.keys(params);
 paramNames.forEach((paramName) => {
   // Find the corresponding HTML checkbox associated with the param
   const input = document.querySelector(`#code-syntax-highlight--${paramName} input`);
+  // Skip params that don't have a corresponding checkbox in the UI
+  if (!input) return;
   // Add event listener to update the corresponding param when the checkbox is changed
   input.addEventListener('change', (event) => {
     // Clone old params to new object to avoid directly changing them

--- a/script.py
+++ b/script.py
@@ -29,6 +29,7 @@ with open(assets_dir / 'extension.json', 'r') as f:
 
 # Define extension config with global params - https://github.com/oobabooga/text-generation-webui/blob/main/docs/07%20%E2%80%90%20Extensions.md#how-to-write-an-extension
 params = {
+    'display_name': 'Code Syntax Highlight',
     'activate': True, # TODO: Separate activate from highlight, so for example we can still enable copy_button without the highlight
     'inline_highlight': False,
     'copy_button': False,
@@ -72,7 +73,7 @@ def ui():
         interface.load(None, None, None, _js=f'() => {{{js_data_proxy_loader+js_modules}}}')
 
     # Display extension settings in the Gradio UI
-    with gr.Accordion('Code Syntax Highlight - Settings', elem_id='code-syntax-highlight_accordion', open=True):
+    with gr.Accordion(label=params['display_name'], elem_id='code-syntax-highlight_accordion', open=True):
         # Accordion style
         gr.HTML(value=f'<style> {css_accordion} </style>')
         # Setting: activate

--- a/script.py
+++ b/script.py
@@ -32,7 +32,7 @@ params = {
     'activate': True, # TODO: Separate activate from highlight, so for example we can still enable copy_button without the highlight
     'inline_highlight': False,
     'copy_button': False,
-    'performance_mode': False,
+    'performance_mode': True,
 }
 
 # JS to check for extension's updates

--- a/script.py
+++ b/script.py
@@ -27,7 +27,7 @@ with open(assets_dir / 'highlightjs-copy.css', 'r') as f:
 with open(assets_dir / 'extension.json', 'r') as f:
     extension_info = json.load(f)
 
-# Define extension config with global params - https://github.com/oobabooga/text-generation-webui/blob/main/docs/Extensions.md#params-dictionary
+# Define extension config with global params - https://github.com/oobabooga/text-generation-webui/blob/main/docs/07%20%E2%80%90%20Extensions.md#how-to-write-an-extension
 params = {
     'activate': True, # TODO: Separate activate from highlight, so for example we can still enable copy_button without the highlight
     'inline_highlight': False,

--- a/script.py
+++ b/script.py
@@ -41,28 +41,8 @@ js_extension_updater = f'''
   if (confirm('Open the GitHub page of Code Syntax Highlight?')) window.open(extensionInfo.gitUrl + '/releases/latest', '_blank');
 '''
 
-# JS to update the specified param so that JS modules can access it
-def js_params_updater(paramName):
-    return '(x) => { ' + f'''
-      const paramName = '{paramName}';
-    ''' + '''
-      const element = document.getElementById('code-syntax-highlight');
-      const params = JSON.parse(element.getAttribute('params'));
-      params[paramName] = x;
-      element.setAttribute('params', JSON.stringify(params));
-    ''' + ' }'
-
 # CSS for the accordion on the Gradio UI
 css_accordion = '''
-  #code-syntax-highlight_accordion p.settings-warning {
-    display: block;
-    color: var(--block-info-text-color, inherit);
-    margin-bottom: 0;
-  }
-  #code-syntax-highlight_accordion.disabled .form {
-    opacity: 0.5;
-    pointer-events: none;
-  }
   #code-syntax-highlight_accordion p.version-label {
     margin: 0;
     line-height: 1rem;
@@ -93,23 +73,36 @@ def ui():
 
     # Display extension settings in the Gradio UI
     with gr.Accordion('Code Syntax Highlight - Settings', elem_id='code-syntax-highlight_accordion', open=True):
-        # Settings warning message and accordion style
-        gr.HTML(value=f'''
-          <style> {css_accordion} </style>
-          <p class="settings-warning">Settings can only be modified when the web UI is not generating text or performing other operations</p>
-        ''')
+        # Accordion style
+        gr.HTML(value=f'<style> {css_accordion} </style>')
         # Setting: activate
-        activate = gr.Checkbox(value=params['activate'], label='Enable extension and syntax highlighting of code snippets')
-        activate.change(lambda x: params.update({'activate': x}), activate, _js=js_params_updater('activate'))
+        gr.Checkbox(
+            value=params['activate'],
+            label='Enable extension and syntax highlighting of code snippets',
+            interactive=True,
+            elem_id='code-syntax-highlight--activate'
+        )
         # Setting: inline_highlight
-        inline_highlight = gr.Checkbox(value=params['inline_highlight'], label='Highlight inline code snippets')
-        inline_highlight.change(lambda x: params.update({'inline_highlight': x}), inline_highlight, _js=js_params_updater('inline_highlight'))
+        gr.Checkbox(
+            value=params['inline_highlight'],
+            label='Highlight inline code snippets',
+            interactive=True,
+            elem_id='code-syntax-highlight--inline_highlight'
+        )
         # Setting: copy_button
-        copy_button = gr.Checkbox(value=params['copy_button'], label='Show button to copy code inside code snippets')
-        copy_button.change(lambda x: params.update({'copy_button': x}), copy_button, _js=js_params_updater('copy_button'))
+        gr.Checkbox(
+            value=params['copy_button'],
+            label='Show button to copy code inside code snippets',
+            interactive=True,
+            elem_id='code-syntax-highlight--copy_button'
+        )
         # Setting: performance_mode
-        performance_mode = gr.Checkbox(value=params['performance_mode'], label='Reduce CPU usage by only highlighting after text generation ends')
-        performance_mode.change(lambda x: params.update({'performance_mode': x}), performance_mode, _js=js_params_updater('performance_mode'))
+        gr.Checkbox(
+            value=params['performance_mode'],
+            label='Reduce CPU usage by only highlighting after text generation ends',
+            interactive=True,
+            elem_id='code-syntax-highlight--performance_mode'
+        )
         # Version info and update check button
         with gr.Row():
             gr.HTML(value=f'<p class="version-label"> Current extension version: {extension_info["version"]} </p>')

--- a/script.py
+++ b/script.py
@@ -111,8 +111,8 @@ def ui():
         copy_button = gr.Checkbox(value=params['copy_button'], label='Show button to copy code inside code snippets')
         copy_button.change(lambda x: params.update({'copy_button': x}), copy_button, _js=js_params_updater('copy_button'))
         # Setting: performance_mode
-        #performance_mode = gr.Checkbox(value=params['performance_mode'], label='Reduce CPU usage by only highlighting after text generation ends')
-        #performance_mode.change(lambda x: params.update({'performance_mode': x}), performance_mode, _js=js_params_updater('performance_mode'))
+        performance_mode = gr.Checkbox(value=params['performance_mode'], label='Reduce CPU usage by only highlighting after text generation ends')
+        performance_mode.change(lambda x: params.update({'performance_mode': x}), performance_mode, _js=js_params_updater('performance_mode'))
         # Version info and update check button
         with gr.Row():
             gr.HTML(value=f'<p class="version-label"> Current extension version: {extension_info["version"]} </p>')

--- a/script.py
+++ b/script.py
@@ -55,9 +55,6 @@ def js_params_updater(paramName):
 # CSS for the accordion on the Gradio UI
 css_accordion = '''
   #code-syntax-highlight_accordion p.settings-warning {
-    display: none;
-  }
-  #code-syntax-highlight_accordion.disabled p.settings-warning {
     display: block;
     color: var(--block-info-text-color, inherit);
     margin-bottom: 0;
@@ -99,7 +96,7 @@ def ui():
         # Settings warning message and accordion style
         gr.HTML(value=f'''
           <style> {css_accordion} </style>
-          <p class="settings-warning">Please wait for text generation to end before changing settings</p>
+          <p class="settings-warning">Settings can only be modified when the web UI is not generating text or performing other operations</p>
         ''')
         # Setting: activate
         activate = gr.Checkbox(value=params['activate'], label='Enable extension and syntax highlighting of code snippets')


### PR DESCRIPTION
The method used to detect the current status of text generation has been updated, and the performance mode that was disabled in [version 1.1.1](https://github.com/DavG25/text-generation-webui-code_syntax_highlight/releases/tag/v1.1.1) is now functional again

The extension will now intercept incoming WebSocket messages from Gradio to detect the text generation status reported by Gradio itself, making the detection more reliable over web UI updates compared to the older method

The performance impact using this new method is negligible: when measured, it adds *at most* around a millisecond to each text token generation, even with a large WebSocket payload

Backward compatibility with older versions of the web UI has not been tested, although it should be noted that this new method is mostly tied to the Gradio version

The method for detecting changes to the settings has also been updated: now the settings are no longer locked when the web UI is generating text