### PR TITLE
Add support for Gradio 4.23

### DIFF
--- a/assets/extension.json
+++ b/assets/extension.json
@@ -1,3 +1,5 @@
 {
   "version": "1.3.0",
+  "gitUrl": "https://github.com/DavG25/text-generation-webui-code_syntax_highlight",
+  "manifestUrl": "https://raw.githubusercontent.com/DavG25/text-generation-webui-code_syntax_highlight/master/assets/extension.json"
 }

--- a/assets/extension.json
+++ b/assets/extension.json
@@ -1,4 +1,3 @@
 {
-  "version": "1.2.0",
-  "gitUrl": "https://github.com/DavG25/text-generation-webui-code_syntax_highlight"
+  "version": "1.3.0",
 }

--- a/assets/main.js
+++ b/assets/main.js
@@ -98,25 +98,25 @@ const copyButtonPlugin = new CopyButtonPlugin();
 function updateCopyButtonPluginStatus() {
   if (params.copy_button === true && !isCopyButtonPluginLoaded) {
     hljs.addPlugin(copyButtonPlugin);
-    document.getElementById('hljs-copy-button').setAttribute('media', 'all');
     isCopyButtonPluginLoaded = true;
   } else if (params.copy_button === false && isCopyButtonPluginLoaded) {
     hljs.removePlugin(copyButtonPlugin);
-    document.getElementById('hljs-copy-button').setAttribute('media', 'not all');
     isCopyButtonPluginLoaded = false;
   }
 }
 
-// Remove copy button associated with the provided code block element
+// Remove copy button associated with the provided code block element along with the no longer necessary wrapper class
 function removeCopyButtonFromCodeElement(codeElement) {
   const preWrapperElement = codeElement.parentElement;
   Array.from(preWrapperElement.querySelectorAll('button[class="hljs-copy-button"], button[class=""][data-copied="false"]')).forEach((copyCodeButton) => {
+    preWrapperElement.classList.remove('hljs-copy-wrapper');
     copyCodeButton.remove();
   });
 }
-// Remove every copy button from all code blocks
+// Remove every copy button from all code blocks along with the no longer necessary wrapper classes
 function removeAllCopyButtons() {
   Array.from(document.querySelectorAll('button[class="hljs-copy-button"], button[class=""][data-copied="false"]')).forEach((copyCodeButton) => {
+    copyCodeButton.parentElement.classList.remove('hljs-copy-wrapper');
     copyCodeButton.remove();
   });
 }
@@ -302,7 +302,7 @@ function setParams(newParams) {
 /*
  * Watch for changes in the HTML inputs (checkboxes)
  *
- * This method is far more reliable then using a proxy and waiting for Gradio
+ * This method is far more reliable than using a proxy and waiting for Gradio
  * to send us the updated values, as sometimes Gradio doesn't correctly queue
  * events and some data is lost
  */

--- a/assets/update-check.js
+++ b/assets/update-check.js
@@ -1,0 +1,60 @@
+// Get UI update button and extension information
+const updateButton = document.getElementById('code-syntax-highlight_updateButton');
+const dataProxy = document.getElementById('code-syntax-highlight');
+const extensionInfo = JSON.parse(dataProxy.getAttribute('info'));
+
+// Fetch remote manifest to compare versions
+const checkForUpdates = () => new Promise((resolve) => {
+  fetch(extensionInfo.manifestUrl, { cache: 'no-store' })
+    .then((response) => response.json())
+    .then((responseData) => {
+      // Get version data for both remote and local manifest
+      const localVersion = extensionInfo.version;
+      const remoteVersion = responseData.version;
+
+      // The localeCompare function can return one of the following values:
+      //  0 = both local and remote versions are equal
+      //  1 = there is a newer remote version
+      // -1 = somehow our version is greater than the remote version
+      // This function is not optimal for every scenario, but in the case of the simple version scheme used by Code Syntax Highlight it works
+      const versionCompare = remoteVersion.localeCompare(localVersion, undefined, { numeric: true, sensitivity: 'base' });
+
+      const sameVersionMessage = `The current version of Code Syntax Highlight (${localVersion}) is already up-to-date`;
+      const newVersionMessage = 'A new version of Code Syntax Highlight is available'
+        + `\n\nCurrent version: ${localVersion}\nLatest version: ${remoteVersion}`
+        + '\n\nDo you want to open the GitHub page to download the latest version?';
+
+      if (versionCompare === 0) {
+        // Local and remote versions are the same
+        alert(sameVersionMessage);
+      } else {
+        // Remote version is newer
+        if (confirm(newVersionMessage) === true) {
+          window.open(`${extensionInfo.gitUrl}/releases/latest`, '_blank');
+        }
+      }
+      resolve(true);
+    })
+    .catch(() => {
+      // Show a default message when there is an error with fetch
+      const noConnectionMessage = 'Do you want to open the GitHub page of Code Syntax Highlight to check for the latest version?';
+      if (confirm(noConnectionMessage) === true) {
+        window.open(`${extensionInfo.gitUrl}/releases/latest`, '_blank');
+      }
+      resolve(false);
+    });
+});
+
+// Add click event to the HTML Gradio button to check for updates
+updateButton.addEventListener('click', async (event) => {
+  // Disable button and update its text
+  const button = event.target;
+  button.disabled = true;
+  const oldTextContent = button.textContent;
+  button.textContent = 'Checking for updates, please wait';
+  // Start checking for updates
+  await checkForUpdates();
+  // Enable button and set old text once update check finished
+  button.textContent = oldTextContent;
+  button.disabled = false;
+});

--- a/script.py
+++ b/script.py
@@ -18,7 +18,7 @@ with open(assets_dir / 'highlightjs-copy.js', 'r') as f:
 with open(assets_dir / 'main.js', 'r') as f:
     js_modules += f.read() + '\n'
 with open(assets_dir / 'update-check.js', 'r') as f:
-    js_update_check = '\n' + f.read() + '\n'
+    js_update_check =  f.read() + '\n'
 with open(assets_dir / 'github.css', 'r') as f:
     css_theme_light = f.read()
 with open(assets_dir / 'github-dark.css', 'r') as f:


### PR DESCRIPTION
The latest Gradio version (4.23) caused a console error due to the JS injection method (with `_js`), this has been fixed by using `custom_js()` which is directly handled by the Web UI

The function to check for extension updates has also been improved

Closes https://github.com/DavG25/text-generation-webui-code_syntax_highlight/issues/8